### PR TITLE
Define DISPLAY in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ ADD entrypoint.sh /
 RUN /setup.sh && \
     rm -f /setup.sh
 
+ENV DISPLAYNUM=99
+ENV SCREENNUM=0
+ENV DISPLAY=':'$DISPLAYNUM'.'$SCREENNUM
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-export DISPLAY=':99.0'
-Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
+Xvfb :$DISPLAYNUM -screen $SCREENNUM 1920x1080x24 > /dev/null 2>&1 &
 
 exec /usr/local/bin/mvn-entrypoint.sh "$@"


### PR DESCRIPTION
As I have learned just now, running `docker exec` does not go through the entrypoint defined in the Dockerfile. Consequently, the `DISPLAY` variable is not always set.

Therefore, I added the variable to the Dockerfile.