### PR TITLE
Inject xvfb start in mvn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ADD setup.sh /
 ADD entrypoint.sh /
 RUN /setup.sh && \
     rm -f /setup.sh
+ADD ./mvn /usr/local/bin/mvn
 
 ENV DISPLAYNUM=99
 ENV SCREENNUM=0

--- a/mvn
+++ b/mvn
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec /entrypoint.sh /usr/bin/mvn "$@"
+


### PR DESCRIPTION
Unfortunately, xvfb is not started when the entrypoint is skipped (like we do in our builds). Therefore, I injected starting xvfb into the Maven binary.