### PR TITLE
Only call entrypoint once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ ARG MAVEN_TAG=latest
 FROM maven:${MAVEN_TAG}
 
 ADD setup.sh /
-ADD entrypoint.sh /
 RUN /setup.sh && \
     rm -f /setup.sh
+
+ADD entrypoint.sh /
+ADD init.sh /
 ADD ./mvn /usr/local/bin/mvn
 
 ENV DISPLAYNUM=99

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
-Xvfb :$DISPLAYNUM -screen $SCREENNUM 1920x1080x24 > /dev/null 2>&1 &
-
+/init.sh
 exec /usr/local/bin/mvn-entrypoint.sh "$@"

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eu
+
+ENTRYPOINT_LOCK_FILE=/tmp/.mdsdtools_init_xvfb.lock
+
+if [ ! -f "$ENTRYPOINT_LOCK_FILE" ]; then
+	# start virtual frame buffer
+	Xvfb :$DISPLAYNUM -screen $SCREENNUM 1920x1080x24 > /dev/null 2>&1 &
+	touch "$ENTRYPOINT_LOCK_FILE"
+fi
+

--- a/mvn
+++ b/mvn
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
-exec /entrypoint.sh /usr/bin/mvn "$@"
-
+/init.sh
+exec /usr/bin/mvn "$@"


### PR DESCRIPTION
This PR fixes an issue when calling `mvn` from within the container multiple times or when calling `mvn` via a command.

The issue occurred because we called the entrypoint from within the `mvn` command. However, the entrypoint unsets a variable, which is important to run the command in the entrypoint.

In the pull request, the entrypoint is no longer called from the `mvn` command. Instead, an initialization script is called before running the original `mvn` binary. In addition, the initialization script only runs once.